### PR TITLE
feat : Move deprecated juzu dependencies from meeds-io to exo - EXO-66190 - meeds-io/MIPs#79

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <org.artofsolving.jodconverter.version>3.0-eXo03</org.artofsolving.jodconverter.version>
     <org.icepdf.version>5.1.1</org.icepdf.version>
     <org.jboss.jboss-commons.version>2.2.22.GA</org.jboss.jboss-commons.version>
+    <org.juzu.version>1.2.0</org.juzu.version>
     <org.powermock.version>2.0.9</org.powermock.version>
     <version.concurrent>1.3.4</version.concurrent>
     <version.htmlparser>2.1</version.htmlparser>
@@ -208,6 +209,41 @@
         <groupId>org.jboss.spec.javax.rmi</groupId>
         <artifactId>jboss-rmi-api_1.0_spec</artifactId>
         <version>${javax.rmi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.juzu</groupId>
+        <artifactId>juzu-core</artifactId>
+        <version>${org.juzu.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.juzu</groupId>
+        <artifactId>juzu-plugins-portlet</artifactId>
+        <version>${org.juzu.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.juzu</groupId>
+        <artifactId>juzu-plugins-less</artifactId>
+        <version>${org.juzu.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.juzu</groupId>
+        <artifactId>juzu-plugins-upload</artifactId>
+        <version>${org.juzu.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.juzu</groupId>
+        <artifactId>juzu-plugins-less4j</artifactId>
+        <version>${org.juzu.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.juzu</groupId>
+        <artifactId>juzu-plugins-validation</artifactId>
+        <version>${org.juzu.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.juzu</groupId>
+        <artifactId>juzu-plugins-webjars</artifactId>
+        <version>${org.juzu.version}</version>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>


### PR DESCRIPTION
Juzu dependency is deprecated in meeds.
We still need it for chat, rh-management and customer space. We move it in eXo side waiting the refactor of these components.