### PR TITLE
feat: Move JCR dependency tree from Meeds - MEED-7742 - Meeds-io/meeds#2537

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,23 @@
     <version.concurrent>1.3.4</version.concurrent>
     <version.htmlparser>2.1</version.htmlparser>
     <version.org.antlr>3.5.2</version.org.antlr>
+    <version.xml-apis>1.4.01</version.xml-apis>
     <com.ibm.icu.version>74.2</com.ibm.icu.version>
     <commons-lang.version>2.6</commons-lang.version>
     <org.apache.httpcomponents.httpclient.version>4.5.13</org.apache.httpcomponents.httpclient.version>
+    <org.infinispan.version>8.2.6.Final</org.infinispan.version>
+    <javax.transaction.version>1.3</javax.transaction.version>
+    <!-- Override dependency inherited from infinispan to make the cluster works on JDK 11 -->
+    <org.jboss.marshalling.version>2.0.10.Final</org.jboss.marshalling.version>
+    <org.jboss.jbossts.version>4.16.6.Final</org.jboss.jbossts.version>
+    <org.jboss.jboss-logging.version>3.3.0.Final</org.jboss.jboss-logging.version>
+    <org.jboss.dmr.version>1.1.1.Final</org.jboss.dmr.version>
+    <version.apache.commons-digester>2.1</version.apache.commons-digester>
+    <!-- 3rd party deprecated libraries versions -->
+    <transactions-jta.version>3.8.0</transactions-jta.version>
+    <com.experlog.xapool.version>1.5.0</com.experlog.xapool.version>
+    <legacy.commons-chain.version>1.3.0</legacy.commons-chain.version>
+    <jgroups.version>3.6.13.Final</jgroups.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -67,6 +81,11 @@
         <groupId>javax.jcr</groupId>
         <artifactId>jcr</artifactId>
         <version>${javax.jcr.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.transaction</groupId>
+        <artifactId>javax.transaction-api</artifactId>
+        <version>${javax.transaction.version}</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
@@ -189,9 +208,46 @@
         <version>${org.icepdf.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-core</artifactId>
+        <version>${org.infinispan.version}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-cachestore-jdbc</artifactId>
+        <version>${org.infinispan.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-commons</artifactId>
+        <version>${org.infinispan.version}</version>
+      </dependency>
+      <!-- Override dependency inherited from infinispan to make the cluster works on JDK 11 -->
+      <dependency>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-common-core</artifactId>
         <version>${org.jboss.jboss-commons.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.marshalling</groupId>
+        <artifactId>jboss-marshalling-osgi</artifactId>
+        <version>${org.jboss.marshalling.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging</artifactId>
+        <version>${org.jboss.jboss-logging.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.jbossts</groupId>
+        <artifactId>jbossjta</artifactId>
+        <version>${org.jboss.jbossts.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.rmi</groupId>
@@ -224,9 +280,41 @@
         <version>${commons-lang.version}</version>
       </dependency>
       <dependency>
+        <groupId>commons-digester</groupId>
+        <artifactId>commons-digester</artifactId>
+        <version>${version.apache.commons-digester}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>${org.apache.httpcomponents.httpclient.version}</version>
+      </dependency>
+      <!-- Third party dependencies used by deprecated services  -->
+      <dependency>
+        <groupId>io.github.weblegacy</groupId>
+        <artifactId>commons-chain-web-jakarta-servlet</artifactId>
+        <version>${legacy.commons-chain.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.experlog</groupId>
+        <artifactId>xapool</artifactId>
+        <version>${com.experlog.xapool.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.atomikos</groupId>
+        <artifactId>transactions-jta</artifactId>
+        <version>${transactions-jta.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jgroups</groupId>
+        <artifactId>jgroups</artifactId>
+        <version>${jgroups.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
+        <version>${version.xml-apis}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This change will declare the dependency tree used in JCR and cleaned up from Meeds to help isolating JCR with its own dependencies.

Resolves https://github.com/Meeds-io/meeds/issues/2537