### PR TITLE
feat: Manage ez-vcard for the email connector's CardDAV contacts - EXO-89119

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 
     <commons-collections4.version>4.4</commons-collections4.version>
     <rome.version>1.18.0</rome.version>
+    <ez-vcard.version>0.12.1</ez-vcard.version>
     <javax.jcr.version>1.0</javax.jcr.version>
     <javax.rmi.version>1.0.6.Final</javax.rmi.version>
     <org.apache.jackrabbit.version>1.6.5</org.apache.jackrabbit.version>
@@ -76,6 +77,30 @@
         <groupId>com.rometools</groupId>
         <artifactId>rome</artifactId>
         <version>${rome.version}</version>
+      </dependency>
+      <!-- vCard parsing, for reading contacts from a CardDAV address book.
+           The excluded dependencies serve vCard's HTML (hCard) and JSON (jCard)
+           representations, which CardDAV never uses: it carries plain vCard.
+           commons-codec and vinnie are kept, the first for base64 photos and the
+           second being the parser's own reader/writer core. -->
+      <dependency>
+        <groupId>com.googlecode.ez-vcard</groupId>
+        <artifactId>ez-vcard</artifactId>
+        <version>${ez-vcard.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>javax.jcr</groupId>


### PR DESCRIPTION
Declares **`ez-vcard`** (BSD 3-clause, 440 KB) so the email-connector add-on can read a user's address book over CardDAV — the protocol carries vCard payloads, and this parses them. Approved by @boubaker.

Consumer side: [email-connector](https://github.com/exoplatform/email-connector) contacts phase 3, task [89119](https://community.exoplatform.com/portal/dw/tasks/taskDetail/89119), [design note](https://community.exoplatform.com/portal/s/273/notes/50450). The add-on will reference it versionless from here and include the jars in its own packaging assembly.

## About the exclusions

ez-vcard declares five non-optional compile dependencies. Three of them serve representations an address book never uses:

| Excluded | Serves |
|---|---|
| `jsoup`, `freemarker` | hCard — vCard embedded in HTML |
| `jackson-core` | jCard — vCard as JSON |

CardDAV carries plain vCard, so what remains is `commons-codec` (base64 photo decoding) and `vinnie` (the parser's own reader/writer core, ~30 KB, same author).

Excluding them keeps the add-on's zip to three small jars instead of dragging freemarker into a mail add-on. The exclusions will be verified against a real parse before the consuming PR merges — if any turns out to be load-bearing, I'll come back and drop that exclusion rather than ship a `NoClassDefFoundError`.

## Why not hand-rolled

vCard in the wild is messy — line folding, vCard 2.1 quoted-printable from old Outlook exports, charset parameters, three photo encodings across 2.1/3.0/4.0. A hand-parser mangles real Gmail and iCloud exports, and those failures look like sync bugs. The add-on keeps the parser behind an interface either way, so the choice stays reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)